### PR TITLE
Add min-wh + indicator if text is empty

### DIFF
--- a/frontend/src/components/editable/EditableTextBox.tsx
+++ b/frontend/src/components/editable/EditableTextBox.tsx
@@ -10,6 +10,7 @@ function EditableTextBox({
 }: EditableTextBoxProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const [isEmpty, setIsEmpty] = useState(false);
   const [text, setText] = useState(initialText);
   const uiContext = useContext(UIContext);
   const spanRef = useRef<HTMLSpanElement>(null);
@@ -66,6 +67,10 @@ function EditableTextBox({
     return cleanup;
   }, [isEditing]);
 
+  useEffect(() => {
+    text.trim() === "" ? setIsEmpty(true) : setIsEmpty(false)
+  }, [text]);
+
   return (
   <span ref={rootRef}>
     {isEditing ? (
@@ -86,8 +91,27 @@ function EditableTextBox({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         onDoubleClick={handleMouseClick}
-        style={isHovered ? { border: '2px solid red' } : {}}
+        style={{
+          display: 'inline-flex',
+          minHeight: '1.2em',
+          minWidth: 10,
+          padding: '0 2px',
+          border: isHovered ? '2px solid red' : ''
+        }}
       >
+        {isEmpty && (
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'inline-block',
+              width: 2,
+              height: '1em',
+              background: 'red',
+              borderRadius: 1,
+              flex: '0 0 auto'
+            }}
+          />
+        )}
         {text}
       </span>
     )}


### PR DESCRIPTION
# 🔍 Related Issue
Fixes ticket #[48](https://tree.taiga.io/project/vicroo-blueprint/issue/48)

# 📝 Description
This PR addresses the issue of not being able to click an `EditableTextBox` if the text has been set to empty.
- Added `minHeight`, `minWidth`, and adjusted the display to `inline-flex` to prevent the span from collapsing to 0px
- Added a placeholder indicator that appears if the text is empty

# 📦 PR Type
<!-- Put an "x" in the boxes that apply ([x])-->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

# ✍ Notes
